### PR TITLE
Improving the supporting of history

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to get more control of the editable text, just extend KnifeText to g
  
  - `app:historyEnable` `true` to enable record history, so you can `redo()` and `undo()`.
     
- - `app:historySize` the record max limit.
+ - `app:maxHistoryCapacity` the record max limit.
     
  - `app:linkColor`
     

--- a/app/src/main/java/io/github/mthli/knifedemo/MainActivity.java
+++ b/app/src/main/java/io/github/mthli/knifedemo/MainActivity.java
@@ -15,6 +15,7 @@ import android.widget.ImageButton;
 import android.widget.Toast;
 
 import io.github.mthli.knife.KnifeText;
+import io.github.mthli.knife.history.KnifeHistory;
 
 public class MainActivity extends Activity {
     private static final String BOLD = "<b>Bold</b><br><br>";
@@ -27,6 +28,8 @@ public class MainActivity extends Activity {
     private static final String EXAMPLE = BOLD + ITALIT + UNDERLINE + STRIKETHROUGH + BULLET + QUOTE + LINK;
 
     private KnifeText knife;
+    private MenuItem undoItem;
+    private MenuItem redoItem;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,6 +37,17 @@ public class MainActivity extends Activity {
         setContentView(R.layout.activity_main);
 
         knife = (KnifeText) findViewById(R.id.knife);
+        knife.setHistoryStateChangeListener(new KnifeHistory.HistoryStateChangeListener() {
+            @Override
+            public void onUndoEnabledStateChange(boolean enabled) {
+               setMenuItemEnabled(undoItem,enabled);
+            }
+
+            @Override
+            public void onRedoEnabledStateChange(boolean enabled) {
+                setMenuItemEnabled(redoItem,enabled);
+            }
+        });
         // ImageGetter coming soon...
         knife.fromHtml(EXAMPLE);
         knife.setSelection(knife.getEditableText().length());
@@ -239,6 +253,12 @@ public class MainActivity extends Activity {
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_main, menu);
+        undoItem = menu.findItem(R.id.undo);
+        redoItem = menu.findItem(R.id.redo);
+
+        setMenuItemEnabled(undoItem,false);
+        setMenuItemEnabled(redoItem,false);
+
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -260,5 +280,11 @@ public class MainActivity extends Activity {
         }
 
         return true;
+    }
+
+
+    private void setMenuItemEnabled(MenuItem itemEnable, boolean enabled) {
+        itemEnable.getIcon().setAlpha(enabled?255:127);
+        itemEnable.setEnabled(enabled);
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -109,7 +109,7 @@
             app:bulletRadius="@dimen/bullet_radius"
             app:bulletGapWidth="@dimen/bullet_gap_width"
             app:historyEnable="true"
-            app:historySize="99"
+            app:historyMaxCapacity="99"
             app:linkColor="@color/blue_500"
             app:linkUnderline="true"
             app:quoteColor="@color/blue_500"

--- a/knife/src/main/java/io/github/mthli/knife/KnifeText.java
+++ b/knife/src/main/java/io/github/mthli/knife/KnifeText.java
@@ -38,12 +38,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.github.mthli.knife.history.KnifeHistory;
-import io.github.mthli.knife.history.SpanRecord;
 import io.github.mthli.knife.history.action.Action;
 import io.github.mthli.knife.history.action.SequentialAction;
 import io.github.mthli.knife.history.action.SpanAddedAction;
 import io.github.mthli.knife.history.action.SpanRemovedAction;
-import io.github.mthli.knife.history.action.SpanReplacedAction;
 import io.github.mthli.knife.history.action.TextChangedAction;
 import io.github.mthli.knife.history.TextChangedRecord;
 import io.github.mthli.knife.history.action.TextReplacedAction;
@@ -113,7 +111,7 @@ public class KnifeText extends EditText implements TextWatcher {
         bulletRadius = array.getDimensionPixelSize(R.styleable.KnifeText_bulletRadius, 0);
         bulletGapWidth = array.getDimensionPixelSize(R.styleable.KnifeText_bulletGapWidth, 0);
         history.setEnabled(array.getBoolean(R.styleable.KnifeText_historyEnable, true));
-        history.setMaxCapacity(array.getInt(R.styleable.KnifeText_historyMaxCapacity, KnifeHistory.DEFAULT_MAX_CAPACITY));
+        history.setMaxCapacity(array.getInt(R.styleable.KnifeText_maxHistoryCapacity, KnifeHistory.DEFAULT_MAX_CAPACITY));
         linkColor = array.getColor(R.styleable.KnifeText_linkColor, 0);
         linkUnderline = array.getBoolean(R.styleable.KnifeText_linkUnderline, true);
         quoteColor = array.getColor(R.styleable.KnifeText_quoteColor, 0);

--- a/knife/src/main/java/io/github/mthli/knife/KnifeText.java
+++ b/knife/src/main/java/io/github/mthli/knife/KnifeText.java
@@ -75,6 +75,15 @@ public class KnifeText extends EditText implements TextWatcher {
     private KnifeHistory history = new KnifeHistory();
 
     private SpannableStringBuilder inputBefore;
+
+    public KnifeHistory.HistoryStateChangeListener getHistoryStateChangeListener() {
+        return history.getStateChangeListener();
+    }
+
+    public void setHistoryStateChangeListener(KnifeHistory.HistoryStateChangeListener historyStateChangeListener) {
+        history.setStateChangeListener(historyStateChangeListener);
+    }
+
     private Editable inputLast;
 
     public KnifeText(Context context) {

--- a/knife/src/main/java/io/github/mthli/knife/history/CapacityLimitedStack.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/CapacityLimitedStack.java
@@ -1,0 +1,43 @@
+package io.github.mthli.knife.history;
+
+import java.util.LinkedList;
+
+/**
+ * Created by cauchywei on 16/1/8.
+ *
+ * CapacityLimitedStack is a stack that has a specified max-capacity
+ * if we push new element into stack when stack is full,
+ * it will remove the element in stack-bottom according to FIFO
+ */
+public class CapacityLimitedStack<T> extends LinkedList<T> {
+
+    public static final int DEFAULT_MAX_CAPACITY = 100;
+    private int maxCapacity = DEFAULT_MAX_CAPACITY;
+
+    @Override
+    public void push(T t) {
+        super.push(t);
+        clear();
+    }
+
+    public int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        if (maxCapacity <= 0) {
+            throw new IllegalArgumentException("Illegal max capacity :" + maxCapacity);
+        }
+
+        this.maxCapacity = maxCapacity;
+        clearExtraElements();
+
+    }
+
+    public void clearExtraElements() {
+        int index = size();
+        while (index > maxCapacity) {
+            remove(--index);
+        }
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/CapacityLimitedStack.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/CapacityLimitedStack.java
@@ -11,13 +11,21 @@ import java.util.LinkedList;
  */
 public class CapacityLimitedStack<T> extends LinkedList<T> {
 
-    public static final int DEFAULT_MAX_CAPACITY = 100;
-    private int maxCapacity = DEFAULT_MAX_CAPACITY;
+    public static final int DEFAULT_MAX_CAPACITY = Integer.MAX_VALUE;
+    private int maxCapacity;
+
+    public CapacityLimitedStack(int maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+
+    public CapacityLimitedStack() {
+        maxCapacity = DEFAULT_MAX_CAPACITY;
+    }
 
     @Override
     public void push(T t) {
         super.push(t);
-        clear();
+        clearExtraElements();
     }
 
     public int getMaxCapacity() {

--- a/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
@@ -9,9 +9,9 @@ import io.github.mthli.knife.history.action.Action;
  */
 public class KnifeHistory {
 
-    interface HistoryStateChangeListener {
-        void onUndoEnabledStateChange(boolean enable);
-        void onRedoEnabledStateChange(boolean enable);
+    public interface HistoryStateChangeListener {
+        void onUndoEnabledStateChange(boolean enabled);
+        void onRedoEnabledStateChange(boolean enabled);
     }
 
     public static final int DEFAULT_MAX_CAPACITY = 100;

--- a/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
@@ -1,0 +1,109 @@
+package io.github.mthli.knife.history;
+
+/**
+ * Created by cauchywei on 16/1/8.
+ */
+public class KnifeHistory {
+
+    interface Action {
+        void perform();
+    }
+
+    interface HistoryStateChangeListener {
+        void onUndoEnabledStateChange(boolean enable);
+        void onRedoEnabledStateChange(boolean enable);
+    }
+
+    private boolean enabled = true;
+    private boolean processing = false;
+    private HistoryStateChangeListener stateChangeListener;
+    private CapacityLimitedStack<Action> undoActionStack = new CapacityLimitedStack<>();
+    private CapacityLimitedStack<Action> redoActionStack = new CapacityLimitedStack<>();
+
+
+    public void record(Action action) {
+        if (enabled) {
+            if (stateChangeListener != null) {
+                if (!redoActionStack.isEmpty()) {
+                    stateChangeListener.onRedoEnabledStateChange(false);
+                }
+                if (undoActionStack.isEmpty()) {
+                    stateChangeListener.onUndoEnabledStateChange(true);
+                }
+            }
+            redoActionStack.clear();
+            undoActionStack.push(action);
+        }
+    }
+    public void undo(){
+
+        if (stateChangeListener != null && redoActionStack.isEmpty()) {
+            stateChangeListener.onRedoEnabledStateChange(true);
+        }
+
+        Action pop = undoActionStack.pop();
+        processing = true;
+        pop.perform();
+        processing = false;
+        redoActionStack.push(pop);
+
+        if (stateChangeListener != null && undoActionStack.isEmpty()) {
+            stateChangeListener.onUndoEnabledStateChange(false);
+        }
+    }
+
+    public void redo(){
+
+        if (stateChangeListener != null && undoActionStack.isEmpty()) {
+            stateChangeListener.onUndoEnabledStateChange(true);
+        }
+
+        Action pop = redoActionStack.pop();
+        processing = true;
+        pop.perform();
+        processing = false;
+        undoActionStack.push(pop);
+
+        if (stateChangeListener != null && redoActionStack.isEmpty() ) {
+            stateChangeListener.onRedoEnabledStateChange(false);
+        }
+
+
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isProcessing() {
+        return processing;
+    }
+
+    public boolean isUndoable() {
+        return !undoActionStack.isEmpty();
+    }
+
+    public boolean isRedoable() {
+        return !redoActionStack.isEmpty();
+    }
+
+    public int getMaxCapacity() {
+        return undoActionStack.getMaxCapacity();
+    }
+
+    public void setMaxCapacity(int maxCapacity) {
+        undoActionStack.setMaxCapacity(maxCapacity);
+    }
+
+    public HistoryStateChangeListener getStateChangeListener() {
+        return stateChangeListener;
+    }
+
+    public void setStateChangeListener(HistoryStateChangeListener stateChangeListener) {
+        this.stateChangeListener = stateChangeListener;
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/KnifeHistory.java
@@ -24,7 +24,7 @@ public class KnifeHistory {
 
 
     public void record(Action action) {
-        if (enabled) {
+        if (enabled && action !=null) {
             if (stateChangeListener != null) {
                 if (!redoActionStack.isEmpty()) {
                     stateChangeListener.onRedoEnabledStateChange(false);

--- a/knife/src/main/java/io/github/mthli/knife/history/SpanRecord.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/SpanRecord.java
@@ -7,9 +7,9 @@ import android.text.ParcelableSpan;
  * Created by cauchywei on 16/1/9.
  */
 public class SpanRecord {
-    Object span;
-    int start;
-    int end;
+    public Object span;
+    public int start;
+    public int end;
 
     public SpanRecord(Object span, int start, int end) {
         this.span = span;

--- a/knife/src/main/java/io/github/mthli/knife/history/SpanRecord.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/SpanRecord.java
@@ -1,0 +1,25 @@
+package io.github.mthli.knife.history;
+
+import android.os.Parcel;
+import android.text.ParcelableSpan;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class SpanRecord {
+    Object span;
+    int start;
+    int end;
+
+    public SpanRecord(Object span, int start, int end) {
+        this.span = span;
+        this.start = start;
+        this.end = end;
+    }
+
+    public void recycle() {
+//        if (spanParcel != null) {
+//            spanParcel.recycle();
+//        }
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/TextChangedRecord.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/TextChangedRecord.java
@@ -1,0 +1,36 @@
+package io.github.mthli.knife.history;
+
+import android.text.Editable;
+import android.text.SpannableStringBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class TextChangedRecord {
+
+    CharSequence changedText;
+    int start;
+    int length;
+    List<SpanRecord> spanRecordList;
+
+    public TextChangedRecord(Editable editable,CharSequence text, int start, int length, Class[] spanClasses) {
+        changedText = text.subSequence(start,start+length);
+        this.start = start;
+        this.length = length;
+
+        spanRecordList = new ArrayList<>();
+        for (Class spanClass : spanClasses) {
+            Object[] spans = editable.getSpans(start, start + length, spanClass);
+            for (Object span : spans) {
+                spanRecordList.add(new SpanRecord(span,editable.getSpanStart(span),editable.getSpanEnd(span)));
+            }
+        }
+    }
+
+    public CharSequence getChangedText() {
+        return changedText;
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/TextChangedRecord.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/TextChangedRecord.java
@@ -11,10 +11,10 @@ import java.util.List;
  */
 public class TextChangedRecord {
 
-    CharSequence changedText;
-    int start;
-    int length;
-    List<SpanRecord> spanRecordList;
+    public CharSequence changedText;
+    public int start;
+    public int length;
+    public List<SpanRecord> spanRecordList;
 
     public TextChangedRecord(Editable editable,CharSequence text, int start, int length, Class[] spanClasses) {
         changedText = text.subSequence(start,start+length);

--- a/knife/src/main/java/io/github/mthli/knife/history/action/Action.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/Action.java
@@ -1,0 +1,14 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public interface Action {
+    void undo(Editable editable);
+
+    void redo(Editable editable);
+
+    void onRemove();
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/Action.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/Action.java
@@ -10,5 +10,5 @@ public interface Action {
 
     void redo(Editable editable);
 
-    void onRemove();
+    void onRemoved();
 }

--- a/knife/src/main/java/io/github/mthli/knife/history/action/SequentialAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/SequentialAction.java
@@ -1,0 +1,34 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class SequentialAction implements Action {
+
+    Action[] actions;
+
+    public SequentialAction(Action ...actions) {
+        this.actions = actions;
+    }
+
+    @Override
+    public void undo(Editable editable) {
+        for (int i = actions.length - 1; i >= 0; i--) {
+            actions[i].undo(editable);
+        }
+    }
+
+    @Override
+    public void redo(Editable editable) {
+        for (int i = 0; i < actions.length; i++) {
+            actions[i].redo(editable);
+        }
+    }
+
+    @Override
+    public void onRemoved() {
+
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/SpanAddedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/SpanAddedAction.java
@@ -1,0 +1,38 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+import android.text.Spanned;
+
+import io.github.mthli.knife.KnifeURLSpan;
+import io.github.mthli.knife.history.SpanRecord;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class SpanAddedAction implements Action{
+
+    private SpanRecord spanRecord;
+
+    public SpanAddedAction(SpanRecord spanRecord) {
+        this.spanRecord = spanRecord;
+    }
+
+    public SpanAddedAction(Object span, int start, int end) {
+        this.spanRecord = new SpanRecord(span, start, end);
+    }
+
+    @Override
+    public void undo(Editable editable) {
+        editable.removeSpan(spanRecord.span);
+    }
+
+    @Override
+    public void redo(Editable editable) {
+        editable.setSpan(spanRecord.span,spanRecord.start,spanRecord.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+
+    @Override
+    public void onRemoved() {
+
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/SpanRemovedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/SpanRemovedAction.java
@@ -1,0 +1,37 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+import android.text.Spanned;
+
+import io.github.mthli.knife.history.SpanRecord;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class SpanRemovedAction implements Action{
+
+    private SpanRecord spanRecord;
+
+    public SpanRemovedAction(SpanRecord spanRecord) {
+        this.spanRecord = spanRecord;
+    }
+
+    public SpanRemovedAction(Object span, int start, int end) {
+        this.spanRecord = new SpanRecord(span, start, end);
+    }
+
+    @Override
+    public void undo(Editable editable) {
+        editable.setSpan(spanRecord.span,spanRecord.start,spanRecord.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+
+    @Override
+    public void redo(Editable editable) {
+        editable.removeSpan(spanRecord.span);
+    }
+
+    @Override
+    public void onRemoved() {
+
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/SpanReplacedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/SpanReplacedAction.java
@@ -1,0 +1,12 @@
+package io.github.mthli.knife.history.action;
+
+import io.github.mthli.knife.history.SpanRecord;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class SpanReplacedAction extends SequentialAction {
+    public SpanReplacedAction(int start, int end, Object spanBefore, Object spanAfter) {
+        super(new SpanRemovedAction(new SpanRecord(spanBefore,start,end)),new SpanAddedAction(new SpanRecord(spanAfter,start,end)));
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/StyleChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/StyleChangedAction.java
@@ -1,0 +1,23 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class StyleChangedAction implements Action {
+    @Override
+    public void undo(Editable editable) {
+
+    }
+
+    @Override
+    public void redo(Editable editable) {
+
+    }
+
+    @Override
+    public void onRemove() {
+
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/StyleChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/StyleChangedAction.java
@@ -17,7 +17,7 @@ public class StyleChangedAction implements Action {
     }
 
     @Override
-    public void onRemove() {
+    public void onRemoved() {
 
     }
 }

--- a/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
@@ -1,0 +1,48 @@
+package io.github.mthli.knife.history.action;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.text.Editable;
+import android.text.ParcelableSpan;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.mthli.knife.history.KnifeHistory;
+import io.github.mthli.knife.history.SpanRecord;
+import io.github.mthli.knife.history.TextChangedRecord;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class TextChangedAction implements KnifeHistory.Action {
+
+    TextChangedRecord before;
+    TextChangedRecord after;
+
+    public TextChangedAction(TextChangedRecord before, TextChangedRecord after) {
+        this.before = before;
+        this.after = after;
+    }
+
+    @Override
+    public void undo(Editable editable) {
+        editable.replace(after.start,after.start+after.changedText.length(),before.getChangedText());
+        for (SpanRecord beforeSpanRecord : before.spanRecordList) {
+            editable.setSpan(beforeSpanRecord.span,beforeSpanRecord.start,beforeSpanRecord.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+        Log.d("action","undo");
+    }
+
+    @Override
+    public void redo(Editable editable) {
+
+    }
+
+    @Override
+    public void onRemove() {
+    }
+}

--- a/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
@@ -26,12 +26,14 @@ public class TextChangedAction implements Action {
         for (SpanRecord beforeSpanRecord : before.spanRecordList) {
             editable.setSpan(beforeSpanRecord.span,beforeSpanRecord.start,beforeSpanRecord.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
-        Log.d("action","undo");
     }
 
     @Override
     public void redo(Editable editable) {
-
+        editable.replace(before.start,before.start+before.changedText.length(),after.getChangedText());
+        for (SpanRecord afterSpan : after.spanRecordList) {
+            editable.setSpan(afterSpan.span,afterSpan.start,afterSpan.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
     }
 
     @Override

--- a/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
@@ -1,24 +1,16 @@
 package io.github.mthli.knife.history.action;
 
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.text.Editable;
-import android.text.ParcelableSpan;
-import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.util.Log;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import io.github.mthli.knife.history.KnifeHistory;
 import io.github.mthli.knife.history.SpanRecord;
 import io.github.mthli.knife.history.TextChangedRecord;
 
 /**
  * Created by cauchywei on 16/1/9.
  */
-public class TextChangedAction implements KnifeHistory.Action {
+public class TextChangedAction implements Action {
 
     TextChangedRecord before;
     TextChangedRecord after;

--- a/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/TextChangedAction.java
@@ -35,6 +35,6 @@ public class TextChangedAction implements Action {
     }
 
     @Override
-    public void onRemove() {
+    public void onRemoved() {
     }
 }

--- a/knife/src/main/java/io/github/mthli/knife/history/action/TextReplacedAction.java
+++ b/knife/src/main/java/io/github/mthli/knife/history/action/TextReplacedAction.java
@@ -1,0 +1,33 @@
+package io.github.mthli.knife.history.action;
+
+import android.text.Editable;
+
+/**
+ * Created by cauchywei on 16/1/9.
+ */
+public class TextReplacedAction implements Action {
+
+    private int start;
+    private CharSequence before,after;
+
+    public TextReplacedAction(int start, CharSequence before, CharSequence after) {
+        this.start = start;
+        this.before = before;
+        this.after = after;
+    }
+
+    @Override
+    public void undo(Editable editable) {
+        editable.replace(start,start+after.length(),before);
+    }
+
+    @Override
+    public void redo(Editable editable) {
+        editable.replace(start,start+before.length(),after);
+    }
+
+    @Override
+    public void onRemoved() {
+
+    }
+}

--- a/knife/src/main/res/values/attrs.xml
+++ b/knife/src/main/res/values/attrs.xml
@@ -21,7 +21,7 @@
         <attr name="bulletRadius" format="reference|dimension" />
         <attr name="bulletGapWidth" format="reference|dimension" />
         <attr name="historyEnable" format="reference|boolean" />
-        <attr name="historyMaxCapacity" format="reference|integer" />
+        <attr name="maxHistoryCapacity" format="reference|integer" />
         <attr name="linkColor" format="reference|color" />
         <attr name="linkUnderline" format="reference|boolean" />
         <attr name="quoteColor" format="reference|color" />

--- a/knife/src/main/res/values/attrs.xml
+++ b/knife/src/main/res/values/attrs.xml
@@ -21,7 +21,7 @@
         <attr name="bulletRadius" format="reference|dimension" />
         <attr name="bulletGapWidth" format="reference|dimension" />
         <attr name="historyEnable" format="reference|boolean" />
-        <attr name="historySize" format="reference|integer" />
+        <attr name="historyMaxCapacity" format="reference|integer" />
         <attr name="linkColor" format="reference|color" />
         <attr name="linkUnderline" format="reference|boolean" />
         <attr name="quoteColor" format="reference|color" />


### PR DESCRIPTION
本PR改进了原Knife内部原始的撤销、回退的功能。Knife原有的机制是监听文本变化，然后把修改前的文本存到一个栈里面，undo的时候把栈顶的元素把当前的文本替换掉，而且只会在文本变化的时候进行历史记录。这种做法虽然简单粗暴，但是每次有文本修改，就把整一套文本复制一次，这种做法太低效了，如果文本内容特别大，『能耗』就更高了。

我在内部维护一个栈（`CapacityLimitedStack`），用于保存每次所做的修改动作（`Action`），这个栈有一个最大的容量限制（`historyMaxCapacity`），如果栈满之后继续`push`，则新action压栈，旧（位于栈底）的Action会被丢弃。

`Action`是一个接口，也就意味着压栈的所有的Action都是可定制的。不管是文本的变动，还是Span的增删变化，undo和redo都能完美地被支持。

每次undo时，栈顶Action被弹出，他的`undo()`方法会被调用。
每次redo时，栈顶Action被弹出，他的`redo()`方法会被调用。

注：Knife的`historySize` 被更名为 `maxHistoryCapacity`
